### PR TITLE
Ignore `*.worker.js.map` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ $RECYCLE.BIN/
 /public/logos
 /public/mix-manifest.json
 /public/*.worker.js
+/public/*.worker.js.map
 /public/*.worker.js.LICENSE.txt
 
 /storage/*.key


### PR DESCRIPTION
Ignore files like `c7d64d4ab445c81bcc7f.worker.js.map` from the `public` folder to keep the repository clean.